### PR TITLE
Add CI/CD workflows and Jenkins pipeline configuration

### DIFF
--- a/.github/workflows/build_run_integration_test.yml
+++ b/.github/workflows/build_run_integration_test.yml
@@ -1,0 +1,23 @@
+name: Build and run the integration tests
+
+on:
+  push:
+    branches: [ "staging" ]
+
+jobs:
+  build_run_integration_test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Run integration tests
+      run: dotnet test Horizons.Tests.Integration/Horizons.Tests.Integration.csproj --no-build --verbosity normal

--- a/.github/workflows/build_run_unit_test.yml
+++ b/.github/workflows/build_run_unit_test.yml
@@ -1,0 +1,23 @@
+name: Build and run the unit tests
+
+on:
+  push:
+    branches: [ "develop" ]
+
+jobs:
+  build_run_unit_test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Run unit test
+      run: dotnet test Horizons.Tests.Unit/Horizons.Tests.Unit.csproj --no-build --verbosity normal

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,21 @@
+pipeline {
+    agent any
+  
+    stages {
+        stage('Restore Dependencies') {
+            steps {
+                bat 'dotnet restore'
+            }
+        }
+        stage('Build') {
+            steps {
+                bat 'dotnet build --no-restore'
+            }
+        }
+        stage('Run Tests') {
+            steps {
+                bat 'dotnet test --no-build --verbosity normal'
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces three key configuration files to enhance our continuous integration process for the Horizons project:

GitHub Actions Integration Workflow:
- The file .github/workflows/build_run_integration_test.yml sets up a workflow that triggers on push events to the staging branch. It checks out the repository, configures .NET 8.0, restores dependencies, builds the project without rebuilding, and runs integration tests for the Horizons.Tests.Integration project.

GitHub Actions Unit Test Workflow:
- The file .github/workflows/build_run_unit_test.yml is configured to run on push events to the develop branch. It follows similar steps—checking out the repository, setting up .NET 8.0, restoring dependencies, building the project, and executing unit tests for the Horizons.Tests.Unit project.

Jenkins Pipeline Configuration:
- The provided Jenkinsfile defines a pipeline that runs on any available agent. It includes stages for restoring dependencies, building the project, and running tests using Windows batch commands.

These additions streamline our CI/CD process, ensuring that the correct tests are executed on the corresponding branches while maintaining consistent build practices across our environments.