### PR TITLE
Add Jenkins and GitHub Actions pipelines

### DIFF
--- a/.github/workflows/build-and-run-unit-test.yml
+++ b/.github/workflows/build-and-run-unit-test.yml
@@ -1,0 +1,24 @@
+name: Build .NET and run unit test
+
+on:
+  push:
+    branches: [ "develop" ]
+    
+jobs:
+  build_run_unit_tests:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout latest version
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Run the unit tests
+      run: dotnet test Horizons.Tests.Unit/Horizons.Tests.Unit.csproj --no-build --verbosity normal 

--- a/.github/workflows/build-and-run-unit-test.yml
+++ b/.github/workflows/build-and-run-unit-test.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout latest version
-    - uses: actions/checkout@v4
+      uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,24 @@
+name: Build .NET and run integration test
+
+on:
+  push:
+    branches: [ "staging" ]
+    
+jobs:
+  build_run_integration_tests:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout latest version
+      uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Run the integration tests
+      run: dotnet test Horizons.Tests.Integration/Horizons.Tests.Integration.csproj --no-build --verbosity normal 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,33 @@
+pipeline {
+    agent any
+
+    triggers {
+        githubPush(
+            branches: ['feature-ci-pipeline']
+        )
+    }
+
+    environment {
+        DOTNET_VERSION = '8.0.x'
+    }
+
+    stages {
+        stage('Restore Dependencies') {
+            steps {
+                bat 'dotnet restore'
+            }
+        }
+
+        stage('Build') {
+            steps {
+                bat 'dotnet build --no-restore'
+            }
+        }
+
+        stage('Run Unit Tests') {
+            steps {
+                bat 'dotnet test --no-build --verbosity normal'
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,12 +1,6 @@
 pipeline {
     agent any
 
-    triggers {
-        githubPush(
-            branches: ['feature-ci-pipeline']
-        )
-    }
-
     environment {
         DOTNET_VERSION = '8.0.x'
     }


### PR DESCRIPTION
This PR sets up the CI/CD by adding Jenkins and GitHub actions pipelines - both build the .NET application, one of them runs the integration tests, the other one runs the unit tests. The Jenkins pipeline builds and runs all the tests. 